### PR TITLE
fix(importer): fail loud on malformed JSONL line (#12)

### DIFF
--- a/internal/sqlite/importer/importer.go
+++ b/internal/sqlite/importer/importer.go
@@ -88,12 +88,21 @@ func (imp *Importer) ImportJSONL(tableName, jsonlPath string, structType reflect
 	// (z.B. freelanceJobSchemas.jsonl mit ~98 KB). Puffer großzügig erhöhen.
 	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
 	count := 0
+	lineNo := 0
 
 	for scanner.Scan() {
-		// Parse JSON
+		lineNo++
+
+		// Leerzeilen (z.B. trailing newline) sind keine Korruption – überspringen.
+		if len(strings.TrimSpace(scanner.Text())) == 0 {
+			continue
+		}
+
+		// Parse JSON. Eine fehlerhafte Zeile bedeutet Schema-Drift oder Korruption
+		// und damit stillen Datenverlust – deshalb fail-loud: abbrechen statt skippen.
 		data := make(map[string]interface{})
 		if err := json.Unmarshal(scanner.Bytes(), &data); err != nil {
-			continue // Skip fehlerhafte Zeilen
+			return fmt.Errorf("malformed JSONL in %s at line %d: %w", jsonlPath, lineNo, err)
 		}
 
 		// Werte extrahieren und einfügen

--- a/internal/sqlite/importer/importer_test.go
+++ b/internal/sqlite/importer/importer_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -309,6 +310,11 @@ func TestImportJSONL_InvalidFile(t *testing.T) {
 	}
 }
 
+// TestImportJSONL_InvalidJSON stellt sicher, dass eine fehlerhafte JSONL-Zeile
+// fail-loud abbricht statt still übersprungen zu werden (Issue #12): eine
+// korrupte/schema-driftete Zeile = versteckter Datenverlust. Der Import muss
+// hart abbrechen und Zeilennummer + Fehler melden, damit der Datenverlust
+// sichtbar wird.
 func TestImportJSONL_InvalidJSON(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmpDB := filepath.Join(tmpDir, "test.db")
@@ -319,7 +325,7 @@ func TestImportJSONL_InvalidJSON(t *testing.T) {
 		Name string `json:"name"`
 	}
 
-	// JSONL mit fehlerhafter Zeile
+	// JSONL mit fehlerhafter Zeile (Zeile 2)
 	jsonlContent := `{"_key":1,"name":"Valid"}
 {invalid json}
 {"_key":2,"name":"AlsoValid"}
@@ -335,17 +341,22 @@ func TestImportJSONL_InvalidJSON(t *testing.T) {
 	createSQL := `CREATE TABLE test (_key INTEGER, name TEXT)`
 	imp.db.Exec(createSQL)
 
-	// Import sollte fehlerhafte Zeilen überspringen
+	// Import MUSS bei fehlerhafter Zeile hart abbrechen (fail-loud).
 	err := imp.ImportJSONL("test", tmpJSONL, reflect.TypeOf(SimpleType{}))
-	if err != nil {
-		t.Fatalf("ImportJSONL should skip invalid lines: %v", err)
+	if err == nil {
+		t.Fatal("ImportJSONL must fail loud on malformed JSONL line, got nil error")
 	}
 
-	// Nur 2 valide Zeilen sollten importiert sein
+	// Fehler muss die Zeilennummer der korrupten Zeile nennen.
+	if !strings.Contains(err.Error(), "line 2") {
+		t.Errorf("error %q should reference the malformed line number (line 2)", err.Error())
+	}
+
+	// Transaktion muss zurückgerollt sein: keine Teil-Daten committed.
 	var count int
 	imp.db.QueryRow("SELECT COUNT(*) FROM test").Scan(&count)
-	if count != 2 {
-		t.Errorf("Row count = %d, want 2 (invalid line skipped)", count)
+	if count != 0 {
+		t.Errorf("Row count = %d, want 0 (transaction must roll back on failure)", count)
 	}
 }
 


### PR DESCRIPTION
## Problem

`internal/sqlite/importer/importer.go` silently dropped any malformed JSONL line:

```go
if err := json.Unmarshal(scanner.Bytes(), &data); err != nil {
    continue // Skip fehlerhafte Zeilen
}
```

A corrupt or schema-drifted SDE line was discarded with no log and no error. The import count was wrong and the data loss was invisible in the generated DB (Issue #12, HIGH).

## Fix (fail-loud)

The import now aborts on a malformed line and returns an error naming the file and line number:

```
malformed JSONL in <path> at line <n>: <unmarshal error>
```

- Schema drift / corruption is now LOUD instead of silently dropping rows.
- Consistent with the file's existing convention of returning wrapped `fmt.Errorf(...: %w)` errors; the caller (`cmd/sde-to-sqlite/main.go`) already `log.Fatalf`s on any import error.
- The surrounding transaction rolls back, so no partial data is committed.
- Blank lines (e.g. a trailing newline) are still tolerated — they are not corruption.

The MED i18n COALESCE fallback in `internal/sqlite/views/cargo.sql` is an intentional, documented i18n fallback and is deliberately left unchanged.

## Tests

`TestImportJSONL_InvalidJSON` was rewritten from asserting the old silent-skip behavior to asserting fail-loud: a malformed line must return an error referencing the line number, and the transaction must roll back (0 rows committed). Verified RED against the old `importer.go` (`got nil error`) and GREEN with the fix.

## Verification

- `go build ./...` — OK
- `go test ./...` — all packages pass
- `go vet ./...` — OK
- `golangci-lint` — no new findings introduced (10 pre-existing issues in unchanged code on both `main` and this branch; none added by this change)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)